### PR TITLE
feat: make global storage accessible from C++

### DIFF
--- a/data/talkactions/scripts/global_storage.lua
+++ b/data/talkactions/scripts/global_storage.lua
@@ -30,6 +30,7 @@ function onSay(player, words, param)
 	end
 
 	player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, string.format("Key %d value is %d", key, Game.getStorageValue(key)))
+	player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, string.format("Key %d value with default 0 is %d", key, Game.getStorageValue(key, 0)))
 
 	return false
 end

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -114,7 +114,7 @@ void Game::setGameState(GameState_t newState)
 			loadMotdNum();
 			loadPlayersRecord();
 			loadAccountStorageValues();
-			LuaScriptInterface::loadGlobalStorages();
+			loadGlobalStorages();
 
 			g_globalEvents->startup();
 			break;
@@ -184,7 +184,10 @@ void Game::saveGameState()
 	}
 
 	Map::save();
-	LuaScriptInterface::saveGlobalStorages();
+
+	if (!saveGlobalStorages()) {
+		std::cout << "[Error - Game::saveGameState] Failed to save global storage values." << std::endl;
+	}
 
 	g_databaseTasks.flush();
 
@@ -5831,4 +5834,59 @@ bool Game::reload(ReloadTypes_t reloadType)
 		}
 	}
 	return true;
+}
+
+void Game::loadGlobalStorages()
+{
+	Database& db = Database::getInstance();
+	DBResult_ptr result = db.storeQuery("SELECT `key`, `value` FROM `global_storage`");
+	if (result) {
+		do {
+			globalStorageMap[result->getNumber<uint32_t>("key")] = result->getNumber<int64_t>("value");
+		} while (result->next());
+	}
+}
+
+bool Game::saveGlobalStorages() const
+{
+	Database& db = Database::getInstance();
+
+	if (!db.executeQuery("DELETE FROM `global_storage`")) {
+		return false;
+	}
+
+	DBInsert storageQuery("INSERT INTO `global_storage` (`key`, `value`) VALUES ");
+
+	for (const auto& it : globalStorageMap) {
+		if (!storageQuery.addRow(fmt::format("{:d}, {:d}", it.first, it.second))) {
+			return false;
+		}
+	}
+
+	if (!storageQuery.execute()) {
+		return false;
+	}
+
+	return true;
+}
+
+int64_t Game::getStorageValue(const uint32_t key, const int64_t defaultValue /*= -1*/) const
+{
+	const auto it = globalStorageMap.find(key);
+	if(it == globalStorageMap.end())
+	{
+		return defaultValue;
+	}
+
+	return it->second;
+}
+
+void Game::setStorageValue(const uint32_t key, const int64_t value)
+{
+	if (value == -1) {
+		globalStorageMap.erase(key);
+		return;
+	}
+
+	globalStorageMap[key] = value;
 }

--- a/src/game.h
+++ b/src/game.h
@@ -489,6 +489,11 @@ class Game
 
 		bool reload(ReloadTypes_t reloadType);
 
+		void loadGlobalStorages();
+		bool saveGlobalStorages() const;
+		int64_t getStorageValue(uint32_t key, int64_t defaultValue = -1) const;
+		void setStorageValue(uint32_t key, int64_t value);
+
 		Groups groups;
 		Map map;
 		Mounts mounts;
@@ -537,6 +542,8 @@ class Game
 
 		std::map<uint32_t, Npc*> npcs;
 		std::map<uint32_t, Monster*> monsters;
+
+		std::map<uint32_t, int64_t> globalStorageMap;
 
 		//list of items that are in trading state, mapped to the player
 		std::map<Item*, uint32_t> tradeItems;

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -48,7 +48,6 @@ ScriptEnvironment::DBResultMap ScriptEnvironment::tempResults;
 uint32_t ScriptEnvironment::lastResultId = 0;
 
 std::multimap<ScriptEnvironment*, Item*> ScriptEnvironment::tempItems;
-std::map<uint32_t, int64_t> globalStorageMap;
 
 LuaEnvironment g_luaEnvironment;
 
@@ -610,40 +609,6 @@ void LuaScriptInterface::callVoidFunction(int params)
 	}
 
 	resetScriptEnv();
-}
-
-void LuaScriptInterface::loadGlobalStorages()
-{
-	Database& db = Database::getInstance();
-	DBResult_ptr result = db.storeQuery("SELECT `key`, `value` FROM `global_storage`");
-	if (result) {
-		do {
-			globalStorageMap[result->getNumber<uint32_t>("key")] = result->getNumber<int64_t>("value");
-		} while (result->next());
-	}
-}
-
-bool LuaScriptInterface::saveGlobalStorages()
-{
-	Database& db = Database::getInstance();
-
-	if (!db.executeQuery("DELETE FROM `global_storage`")) {
-		return false;
-	}
-
-	DBInsert storageQuery("INSERT INTO `global_storage` (`key`, `value`) VALUES ");
-
-	for (const auto& it : globalStorageMap) {
-		if (!storageQuery.addRow(fmt::format("{:d}, {:d}", it.first, it.second))) {
-			return false;
-		}
-	}
-
-	if (!storageQuery.execute()) {
-		return false;
-	}
-
-	return true;
 }
 
 void LuaScriptInterface::pushVariant(lua_State* L, const LuaVariant& var)
@@ -4314,16 +4279,10 @@ int LuaScriptInterface::luaTablePack(lua_State* L)
 // Game
 int32_t LuaScriptInterface::luaGameGetStorageValue(lua_State* L)
 {
-	// Game.getStorageValue(key)
+	// Game.getStorageValue(key, defaultValue)
 	const auto key = getNumber<uint32_t>(L, 1);
-	auto it = globalStorageMap.find(key);
-	if(it != globalStorageMap.end())
-	{
-		lua_pushnumber(L, it->second);
-		return 1;
-	}
-
-	lua_pushnumber(L, -1);
+	const auto defaultValue = getNumber<int64_t>(L, 2, -1);
+	lua_pushnumber(L, g_game.getStorageValue(key, defaultValue));
 	return 1;
 }
 
@@ -4332,12 +4291,7 @@ int32_t LuaScriptInterface::luaGameSetStorageValue(lua_State* L)
 	// Game.setStorageValue(key, value)
 	const auto key = getNumber<uint32_t>(L, 1);
 	const auto value = getNumber<int64_t>(L, 2);
-	if (value == -1) {
-		globalStorageMap.erase(key);
-		return 1;
-	}
-
-	globalStorageMap[key] = value;
+	g_game.setStorageValue(key, value);
 	return 1;
 }
 

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -4279,7 +4279,7 @@ int LuaScriptInterface::luaTablePack(lua_State* L)
 // Game
 int32_t LuaScriptInterface::luaGameGetStorageValue(lua_State* L)
 {
-	// Game.getStorageValue(key, defaultValue)
+	// Game.getStorageValue(key[, defaultValue])
 	const auto key = getNumber<uint32_t>(L, 1);
 	const auto defaultValue = getNumber<int64_t>(L, 2, -1);
 	lua_pushnumber(L, g_game.getStorageValue(key, defaultValue));

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -237,9 +237,6 @@ class LuaScriptInterface
 		bool callFunction(int params);
 		void callVoidFunction(int params);
 
-		static void loadGlobalStorages();
-		static bool saveGlobalStorages();
-
 		//push/pop common structures
 		static void pushThing(lua_State* L, Thing* thing);
 		static void pushVariant(lua_State* L, const LuaVariant& var);


### PR DESCRIPTION
In first implementation of global storage stored in database (like it was in TFS 0.x times):
https://github.com/gesior/forgottenserver-gesior/commit/d03f2e88dbf361b4caa9bd2e0d26eb08302a5314
I made them save in database, but they were stored in `LuaScriptInterface`, not `Game`, so it was hard to read/write them from C++.

If you tried to make some Lua script ex. 'global 10% damage reduction for 24 hours [premium item]', which set 'end time' in global storage. It was hard to read global storage value from C++ code that calculated damage.
With changes from this PR, you can easily read `g_game.getGlobalStorage(123) > time(nullptr)` in `Player::blockHit` and reduce damage by 10%.

I also changed `Game.getStorageValue(key)` (always returned `-1` for not existing storage) to `Game.getStorageValue(key[, defaultValue])`. Now you can configure default value for not existing storage like in this script:
```lua
-- storage with key 123 is not set
local key = 123
print("Value:", Game.getStorageValue(key)) -- -1
print("Value with default 0:", Game.getStorageValue(key, 0)) -- 0
```
I saw multiple scripts like `local value = math.max(0,  Game.getStorageValue(123))` to make default value `0`.
This PR makes code like that easier to read: `local value = Game.getStorageValue(123, 0)`

// TODO: create PR that adds this change to player storage too