### PR TITLE
feat: show decaying item IDs

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4622,10 +4622,17 @@ void Game::checkDecay()
 		it = decayMap.erase(it);
 	}
 
+	std::map<uint16_t, uint64_t> decayedItemsCounter;
 	for (auto item : itemsToDecay) {
+		decayedItemsCounter[item->getID()]++;
 		stopDecay(item);
 		if (item->canDecay()) {
 			internalDecayItem(item);
+		}
+	}
+	if (tooManyItemsToDecay) {
+		for (auto& itemData : decayedItemsCounter) {
+			std::cout << "[Warning - Game::checkDecay] Item ID: " << itemData.first << " count: " << itemData.second << std::endl;
 		}
 	}
 


### PR DESCRIPTION
With "optimized item decay algorithm" ( https://github.com/gesior/forgottenserver-gesior/pull/2 ) decay interval and number of items to decay per event are configurable in `config.lua`:
```
-- Item Decay
decayItemsEventInterval = 50
decayItemsPerEventLimit = 1000
```
Sometimes a warning may appear:
```
[Warning - Game::checkDecay] decayItemsPerEventLimit limited items decay!
```
but you cannot check, what item/items are generating it. 

This PR makes it print item IDs and number of decayed items ex.:
```
[Warning - Game::checkDecay] decayItemsPerEventLimit limited items decay!
[Warning - Game::checkDecay] Item ID: 4617 count: 521
[Warning - Game::checkDecay] Item ID: 4618 count: 479
```
It shows that there are items `4617` and `4618` that decay over 1000 times in a single event - they are probably used on map (.otbm) by mistake. IDs on map should be `4608` and `4609` (`4617` and `4618` decay to these IDs).