### PR TITLE
feat: update C++ libraries for VS2026

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     add_compile_options(-Wimplicit-fallthrough -Wmove)
 endif ()
 
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+
 # Find packages.
 find_package(OpenSSL 3.0.0 REQUIRED COMPONENTS Crypto)
 
@@ -80,7 +82,7 @@ set(BOOST_REQUIRED_COMPONENTS system iostreams locale)
 if (BUILD_TESTING)
     list(APPEND BOOST_REQUIRED_COMPONENTS unit_test_framework)
 endif ()
-find_package(Boost 1.66.0 REQUIRED COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
+find_package(Boost 1.71.0 REQUIRED COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
 
 include_directories(${Boost_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR} ${LUA_INCLUDE_DIR} ${MYSQL_INCLUDE_DIR} ${PUGIXML_INCLUDE_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.19)
 
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -12,11 +12,11 @@
 
 extern ConfigManager g_config;
 
-Connection_ptr ConnectionManager::createConnection(boost::asio::io_service& io_service, ConstServicePort_ptr servicePort)
+Connection_ptr ConnectionManager::createConnection(boost::asio::io_context& io_context, ConstServicePort_ptr servicePort)
 {
 	std::lock_guard<std::mutex> lockClass(connectionManagerLock);
 
-	auto connection = std::make_shared<Connection>(io_service, servicePort);
+	auto connection = std::make_shared<Connection>(io_context, servicePort);
 	connections.insert(connection);
 	return connection;
 }
@@ -100,7 +100,7 @@ void Connection::accept()
 {
 	std::lock_guard<std::recursive_mutex> lockClass(connectionLock);
 	try {
-		readTimer.expires_from_now(std::chrono::seconds(CONNECTION_READ_TIMEOUT));
+		readTimer.expires_after(std::chrono::seconds(CONNECTION_READ_TIMEOUT));
 		readTimer.async_wait(std::bind(&Connection::handleTimeout, std::weak_ptr<Connection>(shared_from_this()), std::placeholders::_1));
 
 		// Read size of the first packet
@@ -221,7 +221,7 @@ void Connection::parseHeader(const boost::system::error_code& error)
 	}
 
 	try {
-		readTimer.expires_from_now(std::chrono::seconds(CONNECTION_READ_TIMEOUT));
+		readTimer.expires_after(std::chrono::seconds(CONNECTION_READ_TIMEOUT));
 		readTimer.async_wait(std::bind(&Connection::handleTimeout, std::weak_ptr<Connection>(shared_from_this()),
 		                                    std::placeholders::_1));
 
@@ -283,7 +283,7 @@ void Connection::parsePacket(const boost::system::error_code& error)
 	}
 
 	try {
-		readTimer.expires_from_now(std::chrono::seconds(CONNECTION_READ_TIMEOUT));
+		readTimer.expires_after(std::chrono::seconds(CONNECTION_READ_TIMEOUT));
 		readTimer.async_wait(std::bind(&Connection::handleTimeout, std::weak_ptr<Connection>(shared_from_this()),
 		                                    std::placeholders::_1));
 
@@ -321,7 +321,7 @@ void Connection::internalSend(const OutputMessage_ptr& msg)
 {
 	protocol->onSendMessage(msg);
 	try {
-		writeTimer.expires_from_now(std::chrono::seconds(CONNECTION_WRITE_TIMEOUT));
+		writeTimer.expires_after(std::chrono::seconds(CONNECTION_WRITE_TIMEOUT));
 		writeTimer.async_wait(std::bind(&Connection::handleTimeout, std::weak_ptr<Connection>(shared_from_this()),
 		                                     std::placeholders::_1));
 
@@ -349,7 +349,7 @@ uint32_t Connection::getIP()
 		return 0;
 	}
 
-	return htonl(endpoint.address().to_v4().to_ulong());
+	return htonl(static_cast<unsigned long>(endpoint.address().to_v4().to_uint()));
 }
 
 void Connection::onWriteOperation(const boost::system::error_code& error)

--- a/src/connection.h
+++ b/src/connection.h
@@ -30,7 +30,7 @@ class ConnectionManager
 			return instance;
 		}
 
-		Connection_ptr createConnection(boost::asio::io_service& io_service, ConstServicePort_ptr servicePort);
+		Connection_ptr createConnection(boost::asio::io_context& io_context, ConstServicePort_ptr servicePort);
 		void releaseConnection(const Connection_ptr& connection);
 		void closeAll();
 
@@ -50,12 +50,12 @@ class Connection : public std::enable_shared_from_this<Connection>
 
 		enum { FORCE_CLOSE = true };
 
-		Connection(boost::asio::io_service& io_service,
+		Connection(boost::asio::io_context& io_context,
 		ConstServicePort_ptr service_port) :
-			readTimer(io_service),
-			writeTimer(io_service),
+			readTimer(io_context),
+			writeTimer(io_context),
 			service_port(std::move(service_port)),
-			socket(io_service),
+			socket(io_context),
 			timeConnected(time(nullptr)) {}
 		~Connection();
 

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -23,11 +23,28 @@ static tfs::detail::Mysql_ptr connectToDatabase(const bool retryIfError)
 	}
 	isFirstAttemptToConnect = false;
 
+// MariaDB requires explicit SSL settings to avoid the following error:
+// "SSL is required, but the server does not support it"
+// For more details see issue #4954 ( https://github.com/otland/forgottenserver/issues/4954 )
+#ifdef MARIADB_VERSION_ID
+	// this needs to be above "goto" otherwise it won't build
+	bool ssl_enforce = false;
+	bool ssl_verify = false;
+#endif
+
 	tfs::detail::Mysql_ptr handle{mysql_init(nullptr)};
 	if (!handle) {
 		std::cout << std::endl << "Failed to initialize MySQL connection handle." << std::endl;
 		goto error;
 	}
+
+// MariaDB explicit SSL settings continued
+#ifdef MARIADB_VERSION_ID
+	mysql_options(handle.get(), MYSQL_OPT_SSL_ENFORCE, &ssl_enforce);
+	mysql_options(handle.get(), MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &ssl_verify);
+	mysql_ssl_set(handle.get(), nullptr, nullptr, nullptr, nullptr, nullptr);
+#endif
+
 	// connects to database
 	if (!mysql_real_connect(handle.get(), g_config.getString(ConfigManager::MYSQL_HOST).c_str(),
 							g_config.getString(ConfigManager::MYSQL_USER).c_str(), g_config.getString(ConfigManager::MYSQL_PASS).c_str(),

--- a/src/definitions.h
+++ b/src/definitions.h
@@ -15,6 +15,7 @@ static constexpr auto CLIENT_VERSION_STR = "10.98";
 static constexpr auto AUTHENTICATOR_DIGITS = 6U;
 static constexpr auto AUTHENTICATOR_PERIOD = 30U;
 
+#define BOOST_ASIO_NO_DEPRECATED
 #define OPENSSL_NO_DEPRECATED
 
 #ifndef __FUNCTION__

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -18,7 +18,7 @@ uint32_t Scheduler::addEvent(SchedulerTask* task)
 		auto it = eventIdTimerMap.emplace(task->getEventId(), boost::asio::steady_timer{io_context});
 		auto& timer = it.first->second;
 
-		timer.expires_from_now(std::chrono::milliseconds(task->getDelay()));
+		timer.expires_after(std::chrono::milliseconds(task->getDelay()));
 		timer.async_wait([this, task](const boost::system::error_code& error) {
 			eventIdTimerMap.erase(task->getEventId());
 

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -48,7 +48,7 @@ class Scheduler : public ThreadHolder<Scheduler>
 		std::atomic<uint32_t> lastEventId{0};
 		std::unordered_map<uint32_t, boost::asio::steady_timer> eventIdTimerMap;
 		boost::asio::io_context io_context;
-		boost::asio::io_context::work work{io_context};
+		boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work{io_context.get_executor()};
 };
 
 extern Scheduler g_scheduler;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -19,14 +19,14 @@ ServiceManager::~ServiceManager()
 
 void ServiceManager::die()
 {
-	io_service.stop();
+	io_context.stop();
 }
 
 void ServiceManager::run()
 {
 	assert(!running);
 	running = true;
-	io_service.run();
+	io_context.run();
 }
 
 void ServiceManager::stop()
@@ -39,7 +39,7 @@ void ServiceManager::stop()
 
 	for (auto& servicePortIt : acceptors) {
 		try {
-			io_service.post(std::bind(&ServicePort::onStopServer, servicePortIt.second));
+			boost::asio::post(io_context, std::bind(&ServicePort::onStopServer, servicePortIt.second));
 		} catch (boost::system::system_error& e) {
 			std::cout << "[ServiceManager::stop] Network Error: " << e.what() << std::endl;
 		}
@@ -47,7 +47,7 @@ void ServiceManager::stop()
 
 	acceptors.clear();
 
-	death_timer.expires_from_now(std::chrono::seconds(3));
+	death_timer.expires_after(std::chrono::seconds(3));
 	death_timer.async_wait(std::bind(&ServiceManager::die, this));
 }
 
@@ -82,7 +82,7 @@ void ServicePort::accept()
 		return;
 	}
 
-	auto connection = ConnectionManager::getInstance().createConnection(io_service, shared_from_this());
+	auto connection = ConnectionManager::getInstance().createConnection(io_context, shared_from_this());
 	acceptor->async_accept(connection->getSocket(), std::bind(&ServicePort::onAccept, shared_from_this(), connection, std::placeholders::_1));
 }
 
@@ -152,10 +152,10 @@ void ServicePort::open(uint16_t port)
 
 	try {
 		if (g_config.getBoolean(ConfigManager::BIND_ONLY_GLOBAL_ADDRESS)) {
-			acceptor.reset(new boost::asio::ip::tcp::acceptor(io_service, boost::asio::ip::tcp::endpoint(
-			            boost::asio::ip::address(boost::asio::ip::address_v4::from_string(g_config.getString(ConfigManager::IP))), serverPort)));
+			acceptor.reset(new boost::asio::ip::tcp::acceptor(io_context, boost::asio::ip::tcp::endpoint(
+			            boost::asio::ip::address(boost::asio::ip::make_address(g_config.getString(ConfigManager::IP))), serverPort)));
 		} else {
-			acceptor.reset(new boost::asio::ip::tcp::acceptor(io_service, boost::asio::ip::tcp::endpoint(
+			acceptor.reset(new boost::asio::ip::tcp::acceptor(io_context, boost::asio::ip::tcp::endpoint(
 			            boost::asio::ip::address(boost::asio::ip::address_v4(INADDR_ANY)), serverPort)));
 		}
 

--- a/src/server.h
+++ b/src/server.h
@@ -47,7 +47,7 @@ class Service final : public ServiceBase
 class ServicePort : public std::enable_shared_from_this<ServicePort>
 {
 	public:
-		explicit ServicePort(boost::asio::io_service& io_service) : io_service(io_service) {}
+		explicit ServicePort(boost::asio::io_context& io_context) : io_context(io_context) {}
 		~ServicePort();
 
 		// non-copyable
@@ -69,7 +69,7 @@ class ServicePort : public std::enable_shared_from_this<ServicePort>
 	private:
 		void accept();
 
-		boost::asio::io_service& io_service;
+		boost::asio::io_context& io_context;
 		std::unique_ptr<boost::asio::ip::tcp::acceptor> acceptor;
 		std::vector<Service_ptr> services;
 
@@ -102,9 +102,9 @@ class ServiceManager
 
 		std::unordered_map<uint16_t, ServicePort_ptr> acceptors;
 
-		boost::asio::io_service io_service;
-		Signals signals{io_service};
-		boost::asio::steady_timer death_timer { io_service };
+		boost::asio::io_context io_context;
+		Signals signals{io_context};
+		boost::asio::steady_timer death_timer { io_context };
 		bool running = false;
 };
 
@@ -121,7 +121,7 @@ bool ServiceManager::add(uint16_t port)
 	auto foundServicePort = acceptors.find(port);
 
 	if (foundServicePort == acceptors.end()) {
-		service_port = std::make_shared<ServicePort>(io_service);
+		service_port = std::make_shared<ServicePort>(io_context);
 		service_port->open(port);
 		acceptors[port] = service_port;
 	} else {

--- a/src/signals.cpp
+++ b/src/signals.cpp
@@ -174,7 +174,7 @@ void dispatchSignalHandler(int signal)
 
 }
 
-Signals::Signals(boost::asio::io_service& service): set(service)
+Signals::Signals(boost::asio::io_context& ioc): set(ioc)
 {
 	set.add(SIGINT);
 	set.add(SIGTERM);

--- a/src/signals.h
+++ b/src/signals.h
@@ -9,7 +9,7 @@ class Signals
 {
 	boost::asio::signal_set set;
 	public:
-		explicit Signals(boost::asio::io_service& service);
+		explicit Signals(boost::asio::io_context& ioc);
 
 	private:
 		void asyncWait();

--- a/vc17/settings.props
+++ b/vc17/settings.props
@@ -19,6 +19,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>otpch.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -51,5 +51,5 @@
     "luajit",
     "libmariadb"
   ],
-  "builtin-baseline": "215a2535590f1f63788ac9bd2ed58ad15e6afdff"
+  "builtin-baseline": "0cf34c184ce990471435b5b9c92edcf7424930b1"
 }


### PR DESCRIPTION
VS2026 uses new compiler that is not detect by some vcpkg `boost-system` libraries. It reports in `(..)\vcpkg\buildtrees\boost-system\config-x64-windows-out.log` error:
```
CMake Error at CMakeLists.txt:75 (message):
  Unsupported MSVC version: 1950
```
In VS2026 is shows:
```
 -- Configuring x64-windows
1>  CMake Error at scripts/cmake/vcpkg_execute_required_process.cmake:127 (message):
1>      Command failed: C:/vcpkgs/vcpkgtest/downloads/tools/ninja/1.13.2-windows/ninja.exe -v
1>      Working Directory: C:/vcpkgs/vcpkgtest/buildtrees/boost-system/x64-windows-rel/vcpkg-parallel-configure
1>EXEC : error code: 1
1>      See logs for more information:
1>        C:\vcpkgs\vcpkgtest\buildtrees\boost-system\config-x64-windows-dbg-CMakeCache.txt.log
1>        C:\vcpkgs\vcpkgtest\buildtrees\boost-system\config-x64-windows-rel-CMakeCache.txt.log
1>        C:\vcpkgs\vcpkgtest\buildtrees\boost-system\config-x64-windows-out.log
```

Changes in this PR:
- updated vcpkg baseline in `vcpkg.json` to `0cf34c184ce990471435b5b9c92edcf7424930b1` (2025-06-20)
- bumped required Boost version to 1.71
- update C++ code that uses Boost ASIO to 1.71
- fixed problem with MariaDB connector that requires SSL connection by default on new library versions
- changed required `cmake` version to `3.19` as it's first version that works with `CMakePresets.json`, so old cmake value `3.17` was invalid

Tested:
- docker build on Ubuntu 22.04 and 24.04
- Windows build in VS2026 with clean vcpkg, tested Debug and Release builds and login to OTS using OTC
- Windows build in VS2022 with VS2026 installed on same PC with clean vcpkg, tested Debug and Release builds and login to OTS using OTC
- Windows build in CLion using cmake and vcpkg profile (with VS2026 compiler as default compiler)
- Windows build in VS2022 on PC with no VS2026 with clean vcpkg (virtual machine with Windows 10 and VS2022)