### PR TITLE
fix: item decay proper server shutdown

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4529,7 +4529,7 @@ void Game::startDecay(Item* item)
 
 void Game::stopDecay(Item* item)
 {
-	if (!item) {
+	if (!item || gameState == GAME_STATE_SHUTDOWN) {
 		return;
 	}
 


### PR DESCRIPTION
During server shutdown (compiled in Debug mode), server first destroys variables `std::map<int64_t, std::map<Item*, Item*>> decayMap` and `std::map<Item*, int64_t> reverseItemDecayMap;` from `game.h` and then deletes server map (`Map map;`).
If there are decaying items on ground, it tries to `stopDecay` and it crashes server, because `reverseItemDecayMap` is already deleted and cannot be used to check, if items are on list of decaying items.

The fix is to add check, if game is in shutdown mode, so `stopDecay` is a no-op during destruction.

VS debugger:
```cpp
std::_Tree<std::_Tmap_traits<Item *,__int64,std::less<Item *>,std::allocator<std::pair<Item * const,__int64>>,0>>::_Find_lower_bound<Item *>(Item * const & _Keyval) Line 1632	C++
std::_Tree<std::_Tmap_traits<Item *,__int64,std::less<Item *>,std::allocator<std::pair<Item * const,__int64>>,0>>::_Find<Item *>(Item * const & _Keyval) Line 1384	C++
std::_Tree<std::_Tmap_traits<Item *,__int64,std::less<Item *>,std::allocator<std::pair<Item * const,__int64>>,0>>::find(Item * const & _Keyval) Line 1394	C++
Game::stopDecay(Item * item) Line 4538	C++
Item::setParent(Cylinder * cylinder) Line 270	C++
Container::~Container() Line 48	C++
Item::decrementReferenceCounter() Line 999	C++
DynamicTile::~DynamicTile() Line 298	C++
Floor::~Floor() Line 940	C++
QTreeLeafNode::~QTreeLeafNode() Line 989	C++
QTreeNode::~QTreeNode() Line 949	C++
QTreeNode::~QTreeNode() Line 949	C++
QTreeNode::~QTreeNode() Line 949	C++
QTreeNode::~QTreeNode() Line 949	C++
QTreeNode::~QTreeNode() Line 949	C++
QTreeNode::~QTreeNode() Line 949	C++
QTreeNode::~QTreeNode() Line 949	C++
QTreeNode::~QTreeNode() Line 949	C++
QTreeNode::~QTreeNode() Line 949	C++
QTreeNode::~QTreeNode() Line 949	C++
QTreeNode::~QTreeNode() Line 949	C++
QTreeNode::~QTreeNode() Line 949	C++
QTreeNode::~QTreeNode() Line 949	C++
Game::~Game() Line 67	C++
```