### PR TITLE
fix: trade stackable items with no empty slot

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2811,8 +2811,8 @@ void Game::playerAcceptTrade(uint32_t playerId)
 		}
 		
 		if (tradePartnerRet == RETURNVALUE_NOERROR && playerRet == RETURNVALUE_NOERROR) {
-			tradePartnerRet = internalAddItem(tradePartner, playerTradeItem, INDEX_WHEREEVER, 0, true);
-			playerRet = internalAddItem(player, partnerTradeItem, INDEX_WHEREEVER, 0, true);
+			tradePartnerRet = internalAddItem(tradePartner, playerTradeItem, INDEX_WHEREEVER, FLAG_IGNOREAUTOSTACK, true);
+			playerRet = internalAddItem(player, partnerTradeItem, INDEX_WHEREEVER, FLAG_IGNOREAUTOSTACK, true);
 			if (tradePartnerRet == RETURNVALUE_NOERROR && playerRet == RETURNVALUE_NOERROR) {
 				playerRet = internalRemoveItem(playerTradeItem, playerTradeItem->getItemCount(), true);
 				tradePartnerRet = internalRemoveItem(partnerTradeItem, partnerTradeItem->getItemCount(), true);


### PR DESCRIPTION
### Bug description

Trading slot item for coins may result in item loss for player (trade and get no coins)

### Steps to reproduce

#### Below is example with depot box, but you can use EQ item from 'slot'. It will fail too.
Important is who starts trade, who accepts it and in what order. Also, second player must trade stackable item, that first player has in backpack and first player must have full BP.

**1. Player no 1 stands next to depot. He has a bag full of items with 1 crystal coins stack and in his depot box he has some item which he will trade (parcel).**

<img width="783" height="515" alt="Image" src="https://github.com/user-attachments/assets/14b154fc-1397-40a6-b676-66dcf6a1c711" />

**2. Player no 2 stands next to this player. He has bag with crystal coins.**

<img width="777" height="419" alt="Image" src="https://github.com/user-attachments/assets/a0d7dbc8-e35a-4cd8-8f25-a162ecaf2928" />

### It is important who starts and accepts trade, as well as the order in which it is executed, so follow steps below

**3. Player 1 - next to depot - starts trade. He selects item from depot box.**

**4. Player 2 trades crystal coin from his bag.**

**5. Player 2 accepts trade.**

**6. Player 1 accepts trade.**


### Actual Behavior

After trade Accept:
- Player 1 has no item in depot box (parcel) and no extra crystal coin [lost money and item]
- Player 2 has new item (parcel) in bag and **keeps his coin** [keeps money and get free item]

### Expected Behavior

After trade Accept:
- Trade is blocked, because there is no place to deliver items to both players.

Problem is that `internalMoveItem` uses flag `FLAG_IGNOREAUTOSTACK` and `internalAddItem` (that executes with `test = true`, not really add item) passes flag `0`, so it thinks there is a place to add item, but there is not, if 'autostack' is disabled.
