### PR TITLE
fix: infinite item decay with 0 duration

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1264,7 +1264,7 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
 		return retMaxCount;
 	}
 
-	if (moveItem && moveItem->getDuration() > 0) {
+	if (moveItem) {
 		startDecay(moveItem);
 	}
 
@@ -1362,9 +1362,7 @@ ReturnValue Game::internalAddItem(Cylinder* toCylinder, Item* item, int32_t inde
 		}
 	}
 
-	if (item->getDuration() > 0) {
-		startDecay(item);
-	}
+	startDecay(item);
 
 	return RETURNVALUE_NOERROR;
 }
@@ -1644,6 +1642,7 @@ Item* Game::transformItem(Item* item, uint16_t newId, int32_t newCount /*= -1*/)
 	if (curType.alwaysOnTop != newType.alwaysOnTop) {
 		//This only occurs when you transform items on tiles from a downItem to a topItem (or vice versa)
 		//Remove the old, and add the new
+		bool wasDecaying = item->getDecaying() == DECAYING_TRUE;
 		cylinder->removeThing(item, item->getItemCount());
 		cylinder->postRemoveNotification(item, cylinder, itemIndex);
 
@@ -1660,6 +1659,10 @@ Item* Game::transformItem(Item* item, uint16_t newId, int32_t newCount /*= -1*/)
 		}
 
 		newParent->postAddNotification(item, cylinder, newParent->getThingIndex(item));
+		// removeThing()/setID() stopped the decay; a transformed item that was decaying must keep decaying
+		if (wasDecaying) {
+			startDecay(item);
+		}
 		return item;
 	}
 
@@ -1713,8 +1716,13 @@ Item* Game::transformItem(Item* item, uint16_t newId, int32_t newCount /*= -1*/)
 				count = newCount;
 			}
 
+			bool wasDecaying = item->getDecaying() == DECAYING_TRUE;
 			cylinder->updateThing(item, itemId, count);
 			cylinder->postAddNotification(item, cylinder, itemIndex);
+			// setID() may have stopped the decay (duration reset); an item that was decaying must keep decaying
+			if (wasDecaying) {
+				startDecay(item);
+			}
 			return item;
 		}
 	}
@@ -1739,9 +1747,7 @@ Item* Game::transformItem(Item* item, uint16_t newId, int32_t newCount /*= -1*/)
 	ReleaseItem(item);
 
 	stopDecay(item);
-	if (newItem->getDuration() > 0) {
-		startDecay(newItem);
-	}
+	startDecay(newItem);
 
 	return newItem;
 }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -166,9 +166,7 @@ Item* Item::clone() const
 	Item* item = Item::CreateItem(id, count);
 	if (attributes) {
 		item->attributes.reset(new ItemAttributes(*attributes));
-		if (item->getDuration() > 0) {
-			g_game.startDecay(item);
-		}
+		g_game.startDecay(item);
 	}
 	return item;
 }
@@ -242,6 +240,12 @@ void Item::onRemoved()
 
 void Item::setID(uint16_t newid)
 {
+	if (id == newid) {
+		// same-id transform (e.g. charge/subtype update) must not reset the duration or stop the decay
+		removeAttribute(ITEM_ATTRIBUTE_CORPSEOWNER);
+		return;
+	}
+
 	const ItemType& prevIt = Item::items[id];
 	id = newid;
 


### PR DESCRIPTION
There are some edge cases in 'optimized item decay system' that make items in slots do not disappear (decay to 0).

**First:** if you move item from EQ slot within last milliseconds of decay (before decay system executes next 'check decay' interval) and equip again later, it will stay forever, because of `getDuration() > 0` comparison, which sees `0` in item attributes
**Second:** if item has charges and duration, removing charges may stop duration - at least that is what I understood from AI analysis
**Third (not fixed):** items in depot does not start to decay on login - it's the same as on TFS 1.4 and other OTS engines, so I decided to keep it like that

Reported by some OTS owner few months ago. **Not validated yet.** Analysis and fix made by AI.

In included files:
- [Polish] full report from 'Fable-5 xhigh 1M context' analysis for 12.56$ [19 minutes] - [analysis-polish_item-decay-bugs-by_Fable-5-xhigh-1M.txt](https://github.com/user-attachments/files/30800525/analysis-polish_item-decay-bugs-by_Fable-5-xhigh-1M.txt)
- [English] reproduction scenario based on Fable analysis made by 'Grok 4.5 (fast)' for 0.50$ [8 SECONDS] - [reproduction-scenarios_english_item-decay-fix-reproduction-scenario_by-Grok-4.5.txt](https://github.com/user-attachments/files/30800526/reproduction-scenarios_english_item-decay-fix-reproduction-scenario_by-Grok-4.5.txt)
- [Polish] analysis of fixed code, re-analyse all item decay scenarios with new code and check, if changes did not implement new bugs by 'Fable-5 xhigh 1M context' for 4.29$ [3 minutes] - [analysis_polish_bugs-after-fix_by-Fable-5-xhigh-1M.txt](https://github.com/user-attachments/files/30800524/analysis_polish_bugs-after-fix_by-Fable-5-xhigh-1M.txt)

In 'after fix' analysis, it found 1 more bug in items system, that blocks 'decay', but it says it was already there before decay system changes. **Also, not validated.** I will fix it in this branch, after I validate all bugs and fixes.
Reproduction scenario of newly found bug (replace ring with other ring in slot):
[reproduction_english_bugs-after-fix_by-Fable-5-xhigh-1M.txt](https://github.com/user-attachments/files/30800627/reproduction_english_bugs-after-fix_by-Fable-5-xhigh-1M.txt)


Prompt to Fable to find these bugs (Polish):
```
w katalogu @src jest najnowszy kod na decay itemow, zostaly w nim wprowadzone poprawki w commitach do tego brancha 1375f340 i 4353c6fc
w katalogu @src-old-decay jest stary kod na decay itemow
nowy system decay zapisuje czas decay w timestamp itema i dodaje go mapy z unixtimestamp jako kluczem, dzieki temu itemy sa przetwarzane tylko kiedy sie koncza, sa dodawane lub usuwane z systemu decay
w starym systemie co sekunde wszystkie itemy dodane do listy decay byly przetwarzane i z kazdego bylo odejmowanie -1000 ms lub jak konczyl sie czas, to je usuwalo

nowy system jest znacznie wydajniejszy, ale jeden z graczy zglosil, ze na jego serwerze itemy czasem sie nie koncza np. 'life ring' czasami trwa wiecznie i nie znika ze slota, nie mam informacji jakie byly wartosci decay/duration na tym serwerze kiedy wystapil problem

jednym z podejrzanych scenariuszy jest wrzucenie do slota przedmiotu ktory ma bardzo malo czasu do konca kilka/kilkadziesiat milisekund - moze podczas dodawania czas sie gdzies zapisuje, a zanim skonczy sie kod na dodawanie, to ta data juz mija - to tylko jedno podejrzenie

inne podejrzenie, to ze na serwerze byly itemy ze starego systemu decay, a zmiana kodu C++ na nowy przy ladowaniu przedmiotu z bazy dany wczytala jakies atrybuty zle, wiec item byl w slocie 'ring' gracza, ale nie odejmowalo mu czasu, bo nie trafil na liste decay - to znowu tylko podejrzenie

przeanalizuj caly system item decay, porownaj go ze starym i ustal, czy sa jakies scenariusze, ktore moge przetestowac w grze, zeby stworzyc item, ktory sie nie konczy
```



